### PR TITLE
Specify node-style module resolution explicitly

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "baseUrl": "./src",
     "sourceMap": true,
     "esModuleInterop": true,
+    "moduleResolution": "node",
     "lib": [
       "es2015",
       "dom"


### PR DESCRIPTION
This change ensures that Typescript uses Node-style module path resolution. Without it, errors appear during `npm build` related to resolving module paths in the `markdown-it` types. 

```
node_modules/@types/markdown-it/index.d.ts:7:29 - error TS2307: 
Cannot find module './lib'.
```

More here: https://www.typescriptlang.org/docs/handbook/module-resolution.html